### PR TITLE
Hide Whisper model options on Intel Macs

### DIFF
--- a/Hearsay/Constants.swift
+++ b/Hearsay/Constants.swift
@@ -60,4 +60,13 @@ enum Constants {
     
     // MARK: - Model
     static let defaultModelId = "qwen3-asr-0.6b"
+
+    /// WhisperKit/CoreML speech models are currently offered only on Apple Silicon.
+    static var supportsWhisperKitModels: Bool {
+        #if arch(arm64)
+        true
+        #else
+        false
+        #endif
+    }
 }

--- a/Hearsay/Models/ModelDownloader.swift
+++ b/Hearsay/Models/ModelDownloader.swift
@@ -25,6 +25,13 @@ final class ModelDownloader: NSObject, ObservableObject, URLSessionDownloadDeleg
         // WhisperKit models
         case whisperTinyEn = "openai_whisper-tiny.en"
         case whisperSmallEn = "openai_whisper-small.en"
+
+        static var availableModels: [Model] {
+            if Constants.supportsWhisperKitModels {
+                return Self.allCases
+            }
+            return Self.allCases.filter { $0.backend == .qwenASR }
+        }
         
         var backend: Backend {
             switch self {
@@ -148,13 +155,18 @@ final class ModelDownloader: NSObject, ObservableObject, URLSessionDownloadDeleg
     // MARK: - Public API
     
     func selectedModelPreference() -> Model? {
-        guard let raw = UserDefaults.standard.string(forKey: Self.selectedModelDefaultsKey) else {
+        guard let raw = UserDefaults.standard.string(forKey: Self.selectedModelDefaultsKey),
+              let model = Model(rawValue: raw),
+              Model.availableModels.contains(model) else {
             return nil
         }
-        return Model(rawValue: raw)
+        return model
     }
     
     func setSelectedModelPreference(_ model: Model) {
+        guard Model.availableModels.contains(model) else {
+            return
+        }
         UserDefaults.standard.set(model.rawValue, forKey: Self.selectedModelDefaultsKey)
     }
     
@@ -205,7 +217,7 @@ final class ModelDownloader: NSObject, ObservableObject, URLSessionDownloadDeleg
     
     /// Get list of installed models
     func installedModels() -> [Model] {
-        Model.allCases.filter { isModelInstalled($0) }
+        Model.availableModels.filter { isModelInstalled($0) }
     }
     
     /// Start downloading a model

--- a/Hearsay/UI/OnboardingWindow.swift
+++ b/Hearsay/UI/OnboardingWindow.swift
@@ -439,7 +439,7 @@ private class OnboardingContentView: NSView {
         modelSelector.orientation = .vertical
         modelSelector.spacing = 10
 
-        let models = ModelDownloader.Model.allCases
+        let models = ModelDownloader.Model.availableModels
         for chunkStart in stride(from: 0, to: models.count, by: 2) {
             let row = NSStackView()
             row.orientation = .horizontal
@@ -560,7 +560,7 @@ private class OnboardingContentView: NSView {
         y -= 60
         
         // Model selector
-        let rows = Int(ceil(Double(ModelDownloader.Model.allCases.count) / 2.0))
+        let rows = Int(ceil(Double(ModelDownloader.Model.availableModels.count) / 2.0))
         let selectorWidth: CGFloat = min(680, bounds.width - 40)
         let selectorHeight: CGFloat = CGFloat(rows) * 100 + CGFloat(max(0, rows - 1)) * 10
         modelSelector.frame = NSRect(x: centerX - selectorWidth/2, y: y - selectorHeight, width: selectorWidth, height: selectorHeight)

--- a/Hearsay/UI/SettingsWindow.swift
+++ b/Hearsay/UI/SettingsWindow.swift
@@ -570,7 +570,7 @@ private class ModelsTabView: NSView {
         modelSelector.orientation = .vertical
         modelSelector.spacing = 12
 
-        let models = ModelDownloader.Model.allCases
+        let models = ModelDownloader.Model.availableModels
         for chunkStart in stride(from: 0, to: models.count, by: 2) {
             let row = NSStackView()
             row.orientation = .horizontal
@@ -692,7 +692,7 @@ private class ModelsTabView: NSView {
         let downloader = ModelDownloader.shared
         let active = downloader.selectedModelPreference()
 
-        for model in ModelDownloader.Model.allCases {
+        for model in ModelDownloader.Model.availableModels {
             let card = modelCards[model]
             card?.setSelected(model == selectedModel)
             card?.setInstalled(downloader.isModelInstalled(model))
@@ -760,7 +760,7 @@ private class ModelsTabView: NSView {
         subtitleLabel.frame = NSRect(x: 20, y: y - 22, width: bounds.width - 40, height: 22)
         y -= 34
 
-        let rows = Int(ceil(Double(ModelDownloader.Model.allCases.count) / 2.0))
+        let rows = Int(ceil(Double(ModelDownloader.Model.availableModels.count) / 2.0))
         let selectorWidth: CGFloat = min(680, bounds.width - 40)
         let selectorHeight: CGFloat = CGFloat(rows) * 100 + CGFloat(max(0, rows - 1)) * 12
         modelSelector.frame = NSRect(x: centerX - selectorWidth / 2, y: y - selectorHeight, width: selectorWidth, height: selectorHeight)


### PR DESCRIPTION
## Summary
This PR prevents selecting WhisperKit/CoreML speech models on Intel Macs.

On Intel, only qwen_asr models are shown/considered. This avoids the reproducible crash reported in #12.

## Changes
- Add `Constants.supportsWhisperKitModels` (true on arm64, false otherwise).
- Add `ModelDownloader.Model.availableModels` to filter model list by platform.
- Use `availableModels` in:
  - Onboarding model selector UI
  - Settings model selector UI
  - Installed model resolution
- Harden selected model preference:
  - Ignore saved model IDs that are unavailable on current platform
  - Ignore attempts to set unavailable model IDs

## Result
- Intel Macs no longer show Whisper model cards.
- Existing saved Whisper preference on Intel is ignored and app falls back to available qwen models.

Closes #12
