### PR TITLE
Add a full-screen screenshot shortcut during recording

### DIFF
--- a/Hearsay/AppDelegate.swift
+++ b/Hearsay/AppDelegate.swift
@@ -270,7 +270,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         hotkeyMonitor.onScreenshotRequested = { [weak self] in
             self?.captureScreenshot()
         }
-        
+
+        hotkeyMonitor.onFullScreenshotRequested = { [weak self] in
+            self?.captureFullScreen()
+        }
+
         // Set up screenshot manager callback — fires when screenshot is actually saved (after drag+release)
         ScreenshotManager.shared.onScreenshotCaptured = { [weak self] count in
             guard let self = self else { return }
@@ -536,6 +540,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         
         logger.info("Capturing screenshot...")
         ScreenshotManager.shared.captureScreenshot()
+    }
+
+    private func captureFullScreen() {
+        guard isRecording else {
+            logger.warning("Not recording, ignoring full-screen screenshot request")
+            return
+        }
+
+        logger.info("Capturing full screen...")
+        ScreenshotManager.shared.captureFullScreen()
     }
     
     private func stopRecording() {

--- a/Hearsay/Core/HotkeyMonitor.swift
+++ b/Hearsay/Core/HotkeyMonitor.swift
@@ -31,6 +31,7 @@ final class HotkeyMonitor {
     var onRecordingStart: (() -> Void)?
     var onRecordingStop: (() -> Void)?
     var onScreenshotRequested: (() -> Void)?
+    var onFullScreenshotRequested: (() -> Void)?
     
     private(set) var state: State = .idle
     private var eventTap: CFMachPort?
@@ -49,6 +50,12 @@ final class HotkeyMonitor {
     private let screenshotHotKeyID: UInt32 = 2
     private var screenshotKeyCode: UInt32 = 21  // '4' key
     private var screenshotModifiers: UInt64 = UInt64(CGEventFlags.maskAlternate.rawValue)
+
+    // Full-screen screenshot hotkey (configurable, default Option+3)
+    private var fullScreenshotHotKeyRef: EventHotKeyRef?
+    private let fullScreenshotHotKeyID: UInt32 = 3
+    private var fullScreenshotKeyCode: UInt32 = 20  // '3' key
+    private var fullScreenshotModifiers: UInt64 = UInt64(CGEventFlags.maskAlternate.rawValue)
     
     private let tapDisableWindow: TimeInterval = 10.0
     private let maxTapDisableEventsBeforeRestart = 3
@@ -85,6 +92,8 @@ final class HotkeyMonitor {
         toggleStopKeyCode = Int64(UserDefaults.standard.object(forKey: "toggleStopKeyCode") as? Int ?? 49)
         screenshotKeyCode = UInt32(UserDefaults.standard.object(forKey: "screenshotKeyCode") as? Int ?? 21)
         screenshotModifiers = UInt64(UserDefaults.standard.object(forKey: "screenshotModifiers") as? Int ?? Int(CGEventFlags.maskAlternate.rawValue))
+        fullScreenshotKeyCode = UInt32(UserDefaults.standard.object(forKey: "fullScreenshotKeyCode") as? Int ?? 20)
+        fullScreenshotModifiers = UInt64(UserDefaults.standard.object(forKey: "fullScreenshotModifiers") as? Int ?? Int(CGEventFlags.maskAlternate.rawValue))
         hotkeyLogger.info("Hotkeys loaded: activation=\(self.activationMode.rawValue), hold=\(self.holdKeyCode), toggleStart=\(self.toggleStartKeyCode)+\(self.toggleStartModifiers), screenshot=\(self.screenshotKeyCode)+\(self.screenshotModifiers)")
         // Reset double-tap state when settings change
         lastTapTime = nil
@@ -146,14 +155,16 @@ final class HotkeyMonitor {
         state = .idle
     }
     
-    /// Enable screenshot hotkey (call when recording starts)
+    /// Enable screenshot hotkeys (call when recording starts)
     func enableScreenshotHotKey() {
         registerScreenshotHotKey()
+        registerFullScreenshotHotKey()
     }
-    
-    /// Disable screenshot hotkey (call when recording stops)
+
+    /// Disable screenshot hotkeys (call when recording stops)
     func disableScreenshotHotKey() {
         unregisterScreenshotHotKey()
+        unregisterFullScreenshotHotKey()
     }
     
     // MARK: - Event Tap Lifecycle
@@ -489,6 +500,8 @@ final class HotkeyMonitor {
                         monitor.handleToggleHotKeyPressed()
                     } else if hotKeyID.id == monitor.screenshotHotKeyID {
                         monitor.handleScreenshotHotKeyPressed()
+                    } else if hotKeyID.id == monitor.fullScreenshotHotKeyID {
+                        monitor.handleFullScreenshotHotKeyPressed()
                     }
                 }
                 return noErr
@@ -568,17 +581,62 @@ final class HotkeyMonitor {
             hotkeyLogger.info("Unregistered screenshot hotkey")
         }
     }
-    
+
+    private func registerFullScreenshotHotKey() {
+        unregisterFullScreenshotHotKey()
+
+        guard fullScreenshotKeyCode > 0 else { return }
+
+        let hotKeyID = EventHotKeyID(signature: fourCharCode("HSY3"), id: fullScreenshotHotKeyID)
+        let carbonModifiers = carbonModifiersFromCGFlags(fullScreenshotModifiers)
+
+        let status = RegisterEventHotKey(
+            fullScreenshotKeyCode,
+            carbonModifiers,
+            hotKeyID,
+            GetApplicationEventTarget(),
+            0,
+            &fullScreenshotHotKeyRef
+        )
+
+        if status != noErr {
+            hotkeyLogger.error("Failed to register full-screen screenshot hotkey: keyCode=\(self.fullScreenshotKeyCode), modifiers=\(self.fullScreenshotModifiers), status=\(status)")
+        } else {
+            hotkeyLogger.info("Registered full-screen screenshot hotkey: keyCode=\(self.fullScreenshotKeyCode), carbonModifiers=\(carbonModifiers)")
+        }
+    }
+
+    private func unregisterFullScreenshotHotKey() {
+        if let ref = fullScreenshotHotKeyRef {
+            UnregisterEventHotKey(ref)
+            fullScreenshotHotKeyRef = nil
+            hotkeyLogger.info("Unregistered full-screen screenshot hotkey")
+        }
+    }
+
     private func handleScreenshotHotKeyPressed() {
         // Only trigger if we're currently recording
         guard state == .recordingHold || state == .recordingToggle else {
             hotkeyLogger.info("Screenshot hotkey pressed but not recording - ignoring")
             return
         }
-        
+
         hotkeyLogger.info("SCREENSHOT HOTKEY - triggering screenshot capture")
         DispatchQueue.main.async { [weak self] in
             self?.onScreenshotRequested?()
+        }
+    }
+
+    private func handleFullScreenshotHotKeyPressed() {
+        // Only trigger if we're currently recording
+        guard state == .recordingHold || state == .recordingToggle else {
+            hotkeyLogger.info("Full-screen screenshot hotkey pressed but not recording - ignoring")
+            return
+        }
+
+        hotkeyLogger.info("FULL-SCREEN SCREENSHOT HOTKEY - triggering capture")
+        DispatchQueue.main.async { [weak self] in
+            self?.onFullScreenshotRequested?()
         }
     }
     

--- a/Hearsay/Core/ScreenshotManager.swift
+++ b/Hearsay/Core/ScreenshotManager.swift
@@ -61,17 +61,29 @@ final class ScreenshotManager {
     
     // MARK: - Screenshot Capture
     
-    /// Capture a screenshot interactively (user selects region)
-    /// Records the timestamp relative to session start for interleaving with transcript
+    /// Capture a screenshot interactively (user selects a region).
+    /// Records the timestamp relative to session start for interleaving with transcript.
     func captureScreenshot() {
+        capture(interactive: true)
+    }
+
+    /// Capture the entire main display immediately (no region selection).
+    /// Records the timestamp relative to session start for interleaving with transcript.
+    func captureFullScreen() {
+        capture(interactive: false)
+    }
+
+    /// Shared capture implementation. `interactive` adds `-i` (region select);
+    /// otherwise `screencapture` grabs the whole main display right away.
+    private func capture(interactive: Bool) {
         let figureNumber = currentSessionFigures.count + 1
         let dateString = ISO8601DateFormatter().string(from: Date())
             .replacingOccurrences(of: ":", with: "-")
             .replacingOccurrences(of: "T", with: "_")
-        
+
         let filename = "figure-\(figureNumber)-\(dateString).png"
         let outputURL = Constants.figuresDirectory.appendingPathComponent(filename)
-        
+
         // Calculate timestamp relative to session start
         let captureTimestamp: TimeInterval
         if let startTime = sessionStartTime {
@@ -79,23 +91,24 @@ final class ScreenshotManager {
         } else {
             captureTimestamp = 0
         }
-        
-        screenshotLogger.info("Starting interactive screenshot capture -> \(outputURL.path) at \(captureTimestamp)s")
-        
-        // Use screencapture command with interactive selection
-        // -i = interactive mode (select area)
+
+        let mode = interactive ? "interactive" : "full-screen"
+        screenshotLogger.info("Starting \(mode) screenshot capture -> \(outputURL.path) at \(captureTimestamp)s")
+
+        // screencapture flags:
+        // -i = interactive mode (select area); omitted = capture whole main display
         // -x = no sound
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/sbin/screencapture")
-        process.arguments = ["-i", "-x", outputURL.path]
-        
+        process.arguments = interactive ? ["-i", "-x", outputURL.path] : ["-x", outputURL.path]
+
         do {
             try process.run()
-            
+
             // Wait for completion in background
             DispatchQueue.global(qos: .userInitiated).async { [weak self] in
                 process.waitUntilExit()
-                
+
                 DispatchQueue.main.async {
                     if process.terminationStatus == 0 && FileManager.default.fileExists(atPath: outputURL.path) {
                         let figure = CapturedFigure(url: outputURL, timestamp: captureTimestamp)

--- a/Hearsay/UI/SettingsWindow.swift
+++ b/Hearsay/UI/SettingsWindow.swift
@@ -207,6 +207,7 @@ private class SettingsTabView: NSView {
     private var holdRow: ShortcutRowView!
     private var toggleRow: ShortcutRowView!
     private var screenshotRow: ShortcutRowView!
+    private var fullScreenshotRow: ShortcutRowView!
     private let resetButton = NSButton(title: "Reset to Defaults", target: nil, action: nil)
     
     override init(frame: NSRect) {
@@ -327,19 +328,35 @@ private class SettingsTabView: NSView {
             captureMode: .keyCombo,
             placeholder: "Not set",
             canClear: true,
-            showSeparator: false
+            showSeparator: true
         ) { [weak self] s in
             UserDefaults.standard.set(s.keyCode, forKey: "screenshotKeyCode")
             UserDefaults.standard.set(Int(s.modifiers), forKey: "screenshotModifiers")
             self?.onHotkeyChanged?()
         }
         shortcutsBox.contentView?.addSubview(screenshotRow)
-        
-        // Conflict detection
+
+        fullScreenshotRow = ShortcutRowView(
+            label: "Full-Screen Screenshot",
+            captureMode: .keyCombo,
+            placeholder: "Not set",
+            canClear: true,
+            showSeparator: false
+        ) { [weak self] s in
+            UserDefaults.standard.set(s.keyCode, forKey: "fullScreenshotKeyCode")
+            UserDefaults.standard.set(Int(s.modifiers), forKey: "fullScreenshotModifiers")
+            self?.onHotkeyChanged?()
+        }
+        shortcutsBox.contentView?.addSubview(fullScreenshotRow)
+
+        // Conflict detection across the three combo shortcuts
         toggleRow.recorder.onConflict = { [weak self] candidate in
             guard let self = self else { return nil }
             if candidate.conflicts(with: self.screenshotRow.recorder.currentShortcut) {
                 return "This shortcut is already used by \"Take Screenshot\"."
+            }
+            if candidate.conflicts(with: self.fullScreenshotRow.recorder.currentShortcut) {
+                return "This shortcut is already used by \"Full-Screen Screenshot\"."
             }
             return nil
         }
@@ -347,6 +364,19 @@ private class SettingsTabView: NSView {
             guard let self = self else { return nil }
             if candidate.conflicts(with: self.toggleRow.recorder.currentShortcut) {
                 return "This shortcut is already used by \"Toggle Record\"."
+            }
+            if candidate.conflicts(with: self.fullScreenshotRow.recorder.currentShortcut) {
+                return "This shortcut is already used by \"Full-Screen Screenshot\"."
+            }
+            return nil
+        }
+        fullScreenshotRow.recorder.onConflict = { [weak self] candidate in
+            guard let self = self else { return nil }
+            if candidate.conflicts(with: self.toggleRow.recorder.currentShortcut) {
+                return "This shortcut is already used by \"Toggle Record\"."
+            }
+            if candidate.conflicts(with: self.screenshotRow.recorder.currentShortcut) {
+                return "This shortcut is already used by \"Take Screenshot\"."
             }
             return nil
         }
@@ -394,6 +424,11 @@ private class SettingsTabView: NSView {
         screenshotRow.recorder.setShortcut(Shortcut(
             keyCode: UserDefaults.standard.object(forKey: "screenshotKeyCode") as? Int ?? 21,
             modifiers: UInt(UserDefaults.standard.object(forKey: "screenshotModifiers") as? Int ?? Int(NSEvent.ModifierFlags.option.rawValue))
+        ))
+
+        fullScreenshotRow.recorder.setShortcut(Shortcut(
+            keyCode: UserDefaults.standard.object(forKey: "fullScreenshotKeyCode") as? Int ?? 20,
+            modifiers: UInt(UserDefaults.standard.object(forKey: "fullScreenshotModifiers") as? Int ?? Int(NSEvent.ModifierFlags.option.rawValue))
         ))
     }
     
@@ -444,7 +479,7 @@ private class SettingsTabView: NSView {
         // Shortcuts box
         let rowH: CGFloat = 40
         let resetH: CGFloat = 32
-        let shortcutsH: CGFloat = rowH * 4 + resetH + 20  // activation + 3 rows + reset + padding
+        let shortcutsH: CGFloat = rowH * 5 + resetH + 20  // activation + 4 rows + reset + padding
         shortcutsBox.frame = NSRect(x: pad, y: y - shortcutsH, width: boxW, height: shortcutsH)
         layoutShortcutsBox()
     }
@@ -470,7 +505,9 @@ private class SettingsTabView: NSView {
         toggleRow.frame = NSRect(x: inset, y: y, width: rowW, height: rowH)
         y -= rowH
         screenshotRow.frame = NSRect(x: inset, y: y, width: rowW, height: rowH)
-        
+        y -= rowH
+        fullScreenshotRow.frame = NSRect(x: inset, y: y, width: rowW, height: rowH)
+
         // Reset button below everything
         resetButton.sizeToFit()
         resetButton.frame.origin = NSPoint(x: cv.bounds.width - inset - resetButton.frame.width, y: y - 28)
@@ -547,6 +584,8 @@ private class SettingsTabView: NSView {
         UserDefaults.standard.set(Int(NSEvent.ModifierFlags.option.rawValue), forKey: "toggleStartModifiers")
         UserDefaults.standard.set(21, forKey: "screenshotKeyCode")
         UserDefaults.standard.set(Int(NSEvent.ModifierFlags.option.rawValue), forKey: "screenshotModifiers")
+        UserDefaults.standard.set(20, forKey: "fullScreenshotKeyCode")
+        UserDefaults.standard.set(Int(NSEvent.ModifierFlags.option.rawValue), forKey: "fullScreenshotModifiers")
         loadSettings()
         onHotkeyChanged?()
     }


### PR DESCRIPTION
## What

Adds a second screenshot shortcut for grabbing the **whole screen** during a recording, alongside the existing region-select one.

Today the screenshot hotkey (**Option+4**) always drops you into interactive region selection. Often you just want the entire screen without dragging a box. This PR adds **Option+3** (default) to capture the full main display **immediately**, with no selection step. The captured image is interleaved into the transcript exactly like a region screenshot (`[Figure N]` + path footer at its timestamp).

The pairing mirrors macOS muscle memory: ⇧⌘3 = full screen, ⇧⌘4 = region.

## How it works

- **`ScreenshotManager`** — `captureScreenshot()` and the new `captureFullScreen()` now share one private `capture(interactive:)` helper. Full-screen runs `screencapture -x <path>` (no `-i`), so it grabs the main display instantly; region keeps `-i -x`. Both record a timestamp and append to the same `currentSessionFigures`, so interleaving is unchanged.
- **`HotkeyMonitor`** — registers a second Carbon hotkey (`fullScreenshotHotKeyID`, default Option+3) with an `onFullScreenshotRequested` callback, loaded/saved via `fullScreenshotKeyCode` / `fullScreenshotModifiers`, and enabled/disabled together with the region screenshot hotkey (so it's only live while recording).
- **`AppDelegate`** — wires `onFullScreenshotRequested` → `captureFullScreen()` (guarded on `isRecording`).
- **Settings → Shortcuts** — new **"Full-Screen Screenshot"** row (default Option+3), with three-way conflict detection against Toggle Record and Take Screenshot, and a reset-to-defaults entry.

## Notes / scope

- Captures the **main display**. Multi-monitor "screen under cursor" or all-displays capture could be a follow-up.
- Like the region screenshot, it only fires **while recording** (both hold and toggle modes).

## Testing

- Builds clean (`xcodegen generate` + `xcodebuild ... -skipMacroValidation`, and via `./run.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
