### PR TITLE
History: inline hover-to-copy + recover failed transcriptions

### DIFF
--- a/Hearsay/AppDelegate.swift
+++ b/Hearsay/AppDelegate.swift
@@ -734,15 +734,102 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         
         // Get audio duration for history
         let audioDuration = getAudioDuration(url: audioURL)
-        
-        do {
-            let text: String
-            
-            if figures.isEmpty && clips.isEmpty {
-                // Simple case: nothing captured mid-recording, just transcribe
-                do {
-                    text = try await transcriber.transcribe(audioURL: audioURL)
-                } catch SpeechTranscriptionError.noOutput {
+
+        // Attempt transcription, auto-retrying once on a hard failure (transient model
+        // errors happen). Empty-output is already retried inside computeTranscript.
+        var output: TranscriptionOutput? = nil
+        var lastError: Error? = nil
+        for attempt in 1...2 {
+            do {
+                output = try await computeTranscript(audioURL: audioURL, figures: figures, clips: clips, audioDuration: audioDuration, transcriptionID: transcriptionID, transcriber: transcriber)
+                break
+            } catch {
+                lastError = error
+                logger.warning("Transcription \(transcriptionID.uuidString.prefix(8)): attempt \(attempt) failed: \(error.localizedDescription)")
+                if attempt == 1 {
+                    diagnosticLog.event("transcription.auto_retry", level: .warning, fields: [
+                        "id": String(transcriptionID.uuidString.prefix(8)),
+                        "reason": "hard_failure"
+                    ])
+                }
+            }
+        }
+
+        if let output = output {
+            await MainActor.run {
+                logger.info("Transcription \(transcriptionID.uuidString.prefix(8)): SUCCESS, checking if stale...")
+                guard self.currentTranscriptionID == transcriptionID else {
+                    logger.info("Transcription \(transcriptionID.uuidString.prefix(8)): STALE (current: \(self.currentTranscriptionID?.uuidString ?? "nil")), skipping delivery")
+                    diagnosticLog.event("transcription.stale", level: .warning, fields: [
+                        "id": String(transcriptionID.uuidString.prefix(8)),
+                        "phase": "delivery"
+                    ])
+                    return
+                }
+
+                switch self.activeDictationMode {
+                case .pasteAtCursor:
+                    self.deliverTranscriptToFocusedApp(output.finalText)
+                case .returnToCaller(let requestId):
+                    self.localAPIServer?.publishResult(
+                        .completed(requestId: requestId, text: output.finalText, durationSeconds: audioDuration)
+                    )
+                    SoundPlayer.shared.play(.paste)
+                }
+
+                // In dev mode, preserve the audio recording
+                var savedAudioPath: String? = nil
+                if Self.isDevMode {
+                    savedAudioPath = self.preserveRecording(audioURL: audioURL)
+                }
+
+                // Save to history
+                HistoryStore.shared.add(text: output.finalText, durationSeconds: audioDuration, audioFilePath: savedAudioPath)
+                diagnosticLog.event("transcription.success", fields: [
+                    "id": String(transcriptionID.uuidString.prefix(8)),
+                    "duration_seconds": String(format: "%.2f", audioDuration),
+                    "raw_length": "\(output.raw.count)",
+                    "processed_length": "\(output.postProcessed.count)",
+                    "final_length": "\(output.finalText.count)",
+                    "delivery": self.activeDictationMode.diagnosticName
+                ])
+
+                self.clearActiveDictationSession()
+
+                // Show success
+                logger.info("Transcription \(transcriptionID.uuidString.prefix(8)): showing done and scheduling dismiss")
+                self.recordingIndicator.setState(.done)
+                self.dismissIndicatorAfterDelay()
+            }
+            logger.info("Transcription complete; output length: \(output.raw.count)")
+        } else {
+            await MainActor.run {
+                self.handleTranscriptionFailure(audioURL: audioURL, audioDuration: audioDuration, transcriptionID: transcriptionID, error: lastError)
+            }
+            logger.error("Transcription error: \(lastError?.localizedDescription ?? "unknown")")
+        }
+
+        // Clean up temp file (a copy has already been preserved on failure)
+        try? FileManager.default.removeItem(at: audioURL)
+    }
+
+    private struct TranscriptionOutput {
+        let raw: String
+        let postProcessed: String
+        let finalText: String
+    }
+
+    /// Run the full transcription pipeline (split/interleave + post-processing) and
+    /// return the produced text. Reused by the initial attempt, the auto-retry, and the
+    /// manual retry of a saved failed recording. Throws on failure.
+    private func computeTranscript(audioURL: URL, figures: [CapturedFigure], clips: [CapturedClip], audioDuration: Double, transcriptionID: UUID, transcriber: any SpeechTranscribing) async throws -> TranscriptionOutput {
+        let text: String
+
+        if figures.isEmpty && clips.isEmpty {
+            // Simple case: nothing captured mid-recording, just transcribe
+            do {
+                text = try await transcriber.transcribe(audioURL: audioURL)
+            } catch SpeechTranscriptionError.noOutput {
                     // qwen_asr can intermittently return empty output.
                     // Retry once before fallback.
                     logger.warning("No transcription output on first attempt, retrying once")
@@ -874,83 +961,81 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
             // Swap clip placeholders for the verbatim copied text AFTER all cleanup,
             // so copied content (code, names) is reproduced exactly.
+            // Swap clip placeholders for the verbatim copied text AFTER all cleanup,
+            // so copied content (code, names) is reproduced exactly.
             let processedText = TranscriptProcessor.process(postProcessedText)
             let finalText = TranscriptInterleaver.substituteClips(processedText, clips: clips)
+            return TranscriptionOutput(raw: text, postProcessed: postProcessedText, finalText: finalText)
+    }
 
-            await MainActor.run {
-                logger.info("Transcription \(transcriptionID.uuidString.prefix(8)): SUCCESS, checking if stale...")
-                guard self.currentTranscriptionID == transcriptionID else {
-                    logger.info("Transcription \(transcriptionID.uuidString.prefix(8)): STALE (current: \(self.currentTranscriptionID?.uuidString ?? "nil")), skipping delivery")
-                    diagnosticLog.event("transcription.stale", level: .warning, fields: [
-                        "id": String(transcriptionID.uuidString.prefix(8)),
-                        "phase": "delivery"
-                    ])
-                    return
-                }
-
-                switch self.activeDictationMode {
-                case .pasteAtCursor:
-                    self.deliverTranscriptToFocusedApp(finalText)
-                case .returnToCaller(let requestId):
-                    self.localAPIServer?.publishResult(
-                        .completed(requestId: requestId, text: finalText, durationSeconds: audioDuration)
-                    )
-                    SoundPlayer.shared.play(.paste)
-                }
-                
-                // In dev mode, preserve the audio recording
-                var savedAudioPath: String? = nil
-                if Self.isDevMode {
-                    savedAudioPath = self.preserveRecording(audioURL: audioURL)
-                }
-                
-                // Save to history
-                HistoryStore.shared.add(text: finalText, durationSeconds: audioDuration, audioFilePath: savedAudioPath)
-                diagnosticLog.event("transcription.success", fields: [
-                    "id": String(transcriptionID.uuidString.prefix(8)),
-                    "duration_seconds": String(format: "%.2f", audioDuration),
-                    "raw_length": "\(text.count)",
-                    "processed_length": "\(postProcessedText.count)",
-                    "final_length": "\(finalText.count)",
-                    "delivery": self.activeDictationMode.diagnosticName
-                ])
-
-                self.clearActiveDictationSession()
-                
-                // Show success
-                logger.info("Transcription \(transcriptionID.uuidString.prefix(8)): showing done and scheduling dismiss")
-                self.recordingIndicator.setState(.done)
-                
-                // Dismiss after delay
-                self.dismissIndicatorAfterDelay()
-            }
-            
-            logger.info("Transcription complete; output length: \(text.count)")
-            
-        } catch {
-            await MainActor.run {
-                logger.info("Transcription \(transcriptionID.uuidString.prefix(8)): ERROR, checking if stale...")
-                guard self.currentTranscriptionID == transcriptionID else {
-                    logger.info("Transcription \(transcriptionID.uuidString.prefix(8)): STALE (current: \(self.currentTranscriptionID?.uuidString ?? "nil")), skipping UI update")
-                    diagnosticLog.event("transcription.stale", level: .warning, fields: [
-                        "id": String(transcriptionID.uuidString.prefix(8)),
-                        "phase": "error"
-                    ])
-                    return
-                }
-                logger.info("Transcription \(transcriptionID.uuidString.prefix(8)): showing error and scheduling dismiss")
-                var fields = diagnosticLog.errorFields(for: error)
-                fields["id"] = String(transcriptionID.uuidString.prefix(8))
-                diagnosticLog.event("transcription.failed", level: .error, fields: fields)
-                self.recordingIndicator.setState(.error("Failed"))
-                self.scheduleIndicatorDismiss(after: 2.0)
-                self.failActiveCallerDictation(error.localizedDescription)
-            }
-            logger.error("Transcription error: \(error.localizedDescription)")
+    /// Handle a transcription that failed even after the auto-retry: preserve the
+    /// audio so nothing is lost, and (for normal dictation) record a failed history
+    /// entry the user can retry later from the History window.
+    @MainActor
+    private func handleTranscriptionFailure(audioURL: URL, audioDuration: Double, transcriptionID: UUID, error: Error?) {
+        logger.info("Transcription \(transcriptionID.uuidString.prefix(8)): ERROR, checking if stale...")
+        guard self.currentTranscriptionID == transcriptionID else {
+            logger.info("Transcription \(transcriptionID.uuidString.prefix(8)): STALE (current: \(self.currentTranscriptionID?.uuidString ?? "nil")), skipping UI update")
+            diagnosticLog.event("transcription.stale", level: .warning, fields: [
+                "id": String(transcriptionID.uuidString.prefix(8)),
+                "phase": "error"
+            ])
+            return
         }
-        
-        // Clean up temp file
-        try? FileManager.default.removeItem(at: audioURL)
+        logger.info("Transcription \(transcriptionID.uuidString.prefix(8)): showing error and scheduling dismiss")
+        if let error = error {
+            var fields = diagnosticLog.errorFields(for: error)
+            fields["id"] = String(transcriptionID.uuidString.prefix(8))
+            diagnosticLog.event("transcription.failed", level: .error, fields: fields)
+        }
+
+        // Preserve the recording so it isn't wasted; record a retryable entry.
+        let isPasteMode: Bool
+        if case .pasteAtCursor = self.activeDictationMode { isPasteMode = true } else { isPasteMode = false }
+        if isPasteMode, let savedPath = self.preserveRecording(audioURL: audioURL) {
+            HistoryStore.shared.add(text: "", durationSeconds: audioDuration, audioFilePath: savedPath, failed: true)
+            logger.info("Saved failed recording for retry: \(savedPath)")
+            diagnosticLog.event("transcription.failed_audio_saved", level: .warning, fields: [
+                "id": String(transcriptionID.uuidString.prefix(8))
+            ])
+        }
+
+        self.recordingIndicator.setState(.error("Failed"))
+        self.scheduleIndicatorDismiss(after: 2.0)
+        self.failActiveCallerDictation(error?.localizedDescription ?? "Transcription failed")
+    }
+
+    /// Re-run transcription on a saved failed recording and, on success, update the
+    /// history entry in place. Transcribes the whole file (figure positions aren't
+    /// persisted, so retries recover the spoken text without figure interleaving).
+    func retryFailedTranscription(_ item: TranscriptionItem, completion: @escaping (Bool) -> Void) {
+        guard let path = item.audioFilePath, FileManager.default.fileExists(atPath: path) else {
+            logger.warning("Retry requested but audio missing for item \(item.id)")
+            completion(false)
+            return
+        }
+        if transcriber == nil { _ = configureTranscriberIfAvailable() }
+        guard let transcriber = transcriber else {
+            completion(false)
+            return
+        }
+
+        let audioURL = URL(fileURLWithPath: path)
+        let duration = item.durationSeconds
+        let retryID = UUID()
+        Task {
+            do {
+                let output = try await computeTranscript(audioURL: audioURL, figures: [], clips: [], audioDuration: duration, transcriptionID: retryID, transcriber: transcriber)
+                await MainActor.run {
+                    HistoryStore.shared.update(item.updating(text: output.finalText, failed: nil))
+                    completion(true)
+                }
+                logger.info("Retry succeeded for item \(item.id)")
+            } catch {
+                logger.error("Retry transcription failed: \(error.localizedDescription)")
+                await MainActor.run { completion(false) }
+            }
+        }
     }
 
     private var currentDictationState: DictationState {
@@ -1104,10 +1189,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         
         do {
             try FileManager.default.copyItem(at: audioURL, to: destURL)
-            logger.info("Dev mode: saved recording to \(destURL.path)")
+            logger.info("Saved recording to \(destURL.path)")
             return destURL.path
         } catch {
-            logger.error("Dev mode: failed to save recording: \(error.localizedDescription)")
+            logger.error("Failed to save recording: \(error.localizedDescription)")
             return nil
         }
     }
@@ -1307,6 +1392,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func showHistory() {
         if historyWindowController == nil {
             historyWindowController = HistoryWindowController()
+            historyWindowController?.onRetry = { [weak self] item, completion in
+                self?.retryFailedTranscription(item, completion: completion)
+            }
         }
         historyWindowController?.showWindow()
     }

--- a/Hearsay/History/HistoryStore.swift
+++ b/Hearsay/History/HistoryStore.swift
@@ -126,10 +126,28 @@ final class HistoryStore {
     }
     
     @discardableResult
-    func add(text: String, durationSeconds: Double, audioFilePath: String? = nil) -> TranscriptionItem {
-        let item = TranscriptionItem(text: text, durationSeconds: durationSeconds, audioFilePath: audioFilePath)
+    func add(text: String, durationSeconds: Double, audioFilePath: String? = nil, failed: Bool? = nil) -> TranscriptionItem {
+        let item = TranscriptionItem(text: text, durationSeconds: durationSeconds, audioFilePath: audioFilePath, failed: failed)
         add(item)
         return item
+    }
+
+    /// Replace an existing item (matched by id) in place, preserving its position.
+    /// Used to update a failed entry to a successful one after a retry.
+    func update(_ item: TranscriptionItem) {
+        for (chunkIdx, chunkMeta) in index.chunks.enumerated() {
+            var items = loadChunk(id: chunkMeta.id)
+            if let itemIdx = items.firstIndex(where: { $0.id == item.id }) {
+                items[itemIdx] = item
+                saveChunk(id: chunkMeta.id, items: items)
+                if chunkIdx == 0 { newestChunkItems = items }
+                historyLogger.info("Updated transcription \(item.id)")
+                DispatchQueue.main.async {
+                    self.onHistoryChanged?()
+                }
+                return
+            }
+        }
     }
     
     /// Get the most recent N items (reads only what's needed).

--- a/Hearsay/History/TranscriptionItem.swift
+++ b/Hearsay/History/TranscriptionItem.swift
@@ -7,15 +7,39 @@ struct TranscriptionItem: Codable, Identifiable {
     let timestamp: Date
     let durationSeconds: Double
     let audioFilePath: String?
-    
-    init(text: String, durationSeconds: Double, audioFilePath: String? = nil) {
+    /// nil/false = succeeded. true = transcription failed; the audio is retained
+    /// (at `audioFilePath`) so it can be re-run. Optional for backward compatibility
+    /// with history saved before this field existed.
+    let failed: Bool?
+
+    /// Whether this entry is a failed transcription awaiting retry.
+    var isFailed: Bool { failed == true }
+
+    init(text: String, durationSeconds: Double, audioFilePath: String? = nil, failed: Bool? = nil) {
         self.id = UUID()
         self.text = text
         self.timestamp = Date()
         self.durationSeconds = durationSeconds
         self.audioFilePath = audioFilePath
+        self.failed = failed
     }
-    
+
+    /// Full initializer preserving identity — used when replacing an existing entry
+    /// (e.g. updating a failed item to a successful one after a retry).
+    init(id: UUID, text: String, timestamp: Date, durationSeconds: Double, audioFilePath: String?, failed: Bool?) {
+        self.id = id
+        self.text = text
+        self.timestamp = timestamp
+        self.durationSeconds = durationSeconds
+        self.audioFilePath = audioFilePath
+        self.failed = failed
+    }
+
+    /// A copy with new text / failed state but the same identity, timestamp, and audio.
+    func updating(text: String, failed: Bool?) -> TranscriptionItem {
+        TranscriptionItem(id: id, text: text, timestamp: timestamp, durationSeconds: durationSeconds, audioFilePath: audioFilePath, failed: failed)
+    }
+
     /// Formatted timestamp for display
     var formattedTime: String {
         let formatter = DateFormatter()
@@ -35,6 +59,7 @@ struct TranscriptionItem: Codable, Identifiable {
     
     /// Truncated text for menu display
     var menuTitle: String {
+        if isFailed { return "⚠️ Transcription failed" }
         let truncated = text.prefix(40)
         return truncated.count < text.count ? "\(truncated)..." : String(truncated)
     }

--- a/Hearsay/UI/HistoryWindow.swift
+++ b/Hearsay/UI/HistoryWindow.swift
@@ -12,6 +12,9 @@ final class HistoryWindowController: NSWindowController {
     private var items: [TranscriptionItem] = []
     private var selectedIndex: Int? = nil
     private var cardViews: [HistoryCardView] = []
+
+    /// Re-run a failed transcription. Provided by AppDelegate; calls back with success.
+    var onRetry: ((TranscriptionItem, @escaping (Bool) -> Void) -> Void)?
     
     private static let pageSize = 100
     private var loadedCount = 0
@@ -91,13 +94,14 @@ final class HistoryWindowController: NSWindowController {
         let clearButton = NSButton(title: "Clear All", target: self, action: #selector(clearAll(_:)))
         clearButton.translatesAutoresizingMaskIntoConstraints = false
         clearButton.bezelStyle = .rounded
-        
-        let copyButton = NSButton(title: "Copy Selected", target: self, action: #selector(copySelected(_:)))
-        copyButton.translatesAutoresizingMaskIntoConstraints = false
-        copyButton.bezelStyle = .rounded
-        
+
+        let hintLabel = NSTextField(labelWithString: "Hover a row to copy")
+        hintLabel.translatesAutoresizingMaskIntoConstraints = false
+        hintLabel.font = .systemFont(ofSize: 11)
+        hintLabel.textColor = .tertiaryLabelColor
+
         buttonBar.addSubview(clearButton)
-        buttonBar.addSubview(copyButton)
+        buttonBar.addSubview(hintLabel)
         contentView.addSubview(buttonBar)
         
         NSLayoutConstraint.activate([
@@ -121,10 +125,10 @@ final class HistoryWindowController: NSWindowController {
             // Buttons
             clearButton.leadingAnchor.constraint(equalTo: buttonBar.leadingAnchor, constant: 16),
             clearButton.centerYAnchor.constraint(equalTo: buttonBar.centerYAnchor),
-            
-            copyButton.leadingAnchor.constraint(equalTo: clearButton.trailingAnchor, constant: 12),
-            copyButton.centerYAnchor.constraint(equalTo: buttonBar.centerYAnchor),
-            
+
+            hintLabel.trailingAnchor.constraint(equalTo: buttonBar.trailingAnchor, constant: -16),
+            hintLabel.centerYAnchor.constraint(equalTo: buttonBar.centerYAnchor),
+
             // Wrapper sizing
             wrapperView.widthAnchor.constraint(equalTo: scrollView.contentView.widthAnchor)
         ])
@@ -194,7 +198,14 @@ final class HistoryWindowController: NSWindowController {
             card.translatesAutoresizingMaskIntoConstraints = false
             card.configure(with: item, isEven: index % 2 == 0)
             card.index = index
-            
+
+            let capturedItem = item
+            card.onCopy = { [weak self] in self?.copyItem(capturedItem) }
+            card.onRetry = { [weak self, weak card] in
+                guard let self = self, let card = card else { return }
+                self.retryItem(capturedItem, card: card)
+            }
+
             let clickGesture = NSClickGestureRecognizer(target: self, action: #selector(cardClicked(_:)))
             card.addGestureRecognizer(clickGesture)
             
@@ -262,21 +273,36 @@ final class HistoryWindowController: NSWindowController {
     // MARK: - Actions
     
     @objc private func copySelected(_ sender: Any) {
-        guard let index = selectedIndex, index < items.count else {
-            // Flash window title if nothing selected
-            window?.title = "Select an item first"
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in
-                self?.window?.title = "Transcription History"
-            }
-            return
-        }
-        
-        let item = items[index]
+        guard let index = selectedIndex, index < items.count else { return }
+        copyItem(items[index])
+    }
+
+    /// Copy a specific item's text to the clipboard, with a brief title confirmation.
+    private func copyItem(_ item: TranscriptionItem) {
+        guard !item.isFailed else { return }
         TextInserter.copyToClipboard(item.text)
-        
-        // Visual feedback
-        window?.title = "Copied!"
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+        flashTitle("Copied!")
+    }
+
+    /// Re-run a failed item's transcription, updating the card while it works.
+    private func retryItem(_ item: TranscriptionItem, card: HistoryCardView) {
+        guard let onRetry = onRetry else { return }
+        card.setRetrying(true)
+        onRetry(item) { [weak self, weak card] success in
+            DispatchQueue.main.async {
+                card?.setRetrying(false)
+                if success {
+                    self?.loadHistory()  // refresh so the recovered text replaces the failed row
+                } else {
+                    self?.flashTitle("Retry failed")
+                }
+            }
+        }
+    }
+
+    private func flashTitle(_ message: String) {
+        window?.title = message
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) { [weak self] in
             self?.window?.title = "Transcription History"
         }
     }
@@ -325,8 +351,17 @@ private class HistoryCardView: NSView {
     private let textLabel = NSTextField(labelWithString: "")
     private let timeLabel = NSTextField(labelWithString: "")
     private let figuresBadge = NSTextField(labelWithString: "")
+    private let copyButton = NSButton()
+    private let retryButton = NSButton()
+    private var trackingArea: NSTrackingArea?
     private var isSelectedState = false
     private var isEvenRow = false
+    private var isFailedItem = false
+
+    /// Copy this row's text. Set by the controller.
+    var onCopy: (() -> Void)?
+    /// Retry this failed row's transcription. Set by the controller.
+    var onRetry: (() -> Void)?
     
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -369,43 +404,119 @@ private class HistoryCardView: NSView {
         figuresBadge.textColor = .secondaryLabelColor
         figuresBadge.isHidden = true
         addSubview(figuresBadge)
-        
+
+        // Inline copy button — appears on hover (success rows only)
+        copyButton.translatesAutoresizingMaskIntoConstraints = false
+        copyButton.isBordered = false
+        copyButton.bezelStyle = .regularSquare
+        copyButton.imagePosition = .imageOnly
+        copyButton.image = NSImage(systemSymbolName: "doc.on.doc", accessibilityDescription: "Copy")
+        copyButton.contentTintColor = .secondaryLabelColor
+        copyButton.toolTip = "Copy"
+        copyButton.target = self
+        copyButton.action = #selector(copyTapped)
+        copyButton.isHidden = true
+        addSubview(copyButton)
+
+        // Inline retry button — shown on failed rows
+        retryButton.translatesAutoresizingMaskIntoConstraints = false
+        retryButton.bezelStyle = .rounded
+        retryButton.controlSize = .small
+        retryButton.title = "Retry"
+        retryButton.toolTip = "Re-run transcription on the saved audio"
+        retryButton.target = self
+        retryButton.action = #selector(retryTapped)
+        retryButton.isHidden = true
+        addSubview(retryButton)
+
         NSLayoutConstraint.activate([
-            // Text — pinned top, single line
+            // Text — pinned top, single line (leave room on the right for the buttons)
             textLabel.topAnchor.constraint(equalTo: topAnchor, constant: 10),
             textLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
-            textLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -14),
-            
+            textLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -72),
+
             // Time — fixed below text, pinned to bottom
             timeLabel.topAnchor.constraint(equalTo: textLabel.bottomAnchor, constant: 6),
             timeLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 14),
             timeLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -10),
-            
+
             // Figures badge - bottom right
             figuresBadge.centerYAnchor.constraint(equalTo: timeLabel.centerYAnchor),
-            figuresBadge.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -14)
+            figuresBadge.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -14),
+
+            // Copy button - top right
+            copyButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+            copyButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            copyButton.widthAnchor.constraint(equalToConstant: 20),
+            copyButton.heightAnchor.constraint(equalToConstant: 20),
+
+            // Retry button - right, vertically centered
+            retryButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+            retryButton.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingArea = trackingArea { removeTrackingArea(trackingArea) }
+        let area = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseEnteredAndExited, .activeInActiveApp, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(area)
+        trackingArea = area
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        if !isFailedItem, onCopy != nil { copyButton.isHidden = false }
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        if !isFailedItem { copyButton.isHidden = true }
+    }
+
+    @objc private func copyTapped() { onCopy?() }
+    @objc private func retryTapped() { onRetry?() }
+
+    /// Reflect retry-in-progress state on the button.
+    func setRetrying(_ retrying: Bool) {
+        retryButton.isEnabled = !retrying
+        retryButton.title = retrying ? "Retrying…" : "Retry"
     }
     
     func configure(with item: TranscriptionItem, isEven: Bool) {
         self.isEvenRow = isEven
-        
-        // Clean up display text — single line preview, full text on hover
-        let displayText = cleanDisplayText(item.text)
-        textLabel.stringValue = displayText
-        textLabel.toolTip = item.text
-        
-        timeLabel.stringValue = item.formattedTime
-        
-        // Count figures
-        let figureCount = countFigures(in: item.text)
-        if figureCount > 0 {
-            figuresBadge.stringValue = "📎 \(figureCount) figure\(figureCount == 1 ? "" : "s")"
-            figuresBadge.isHidden = false
-        } else {
+        self.isFailedItem = item.isFailed
+
+        if item.isFailed {
+            // Failed transcription: show a clear label + a Retry affordance.
+            textLabel.stringValue = "⚠️ Transcription failed — audio saved"
+            textLabel.toolTip = "Transcription failed. Click Retry to run it again on the saved audio."
+            copyButton.isHidden = true
+            retryButton.isHidden = false
+            setRetrying(false)
             figuresBadge.isHidden = true
+        } else {
+            // Clean up display text — single line preview, full text on hover
+            let displayText = cleanDisplayText(item.text)
+            textLabel.stringValue = displayText
+            textLabel.toolTip = item.text
+            retryButton.isHidden = true
+            copyButton.isHidden = true  // revealed on hover
+
+            // Count figures
+            let figureCount = countFigures(in: item.text)
+            if figureCount > 0 {
+                figuresBadge.stringValue = "📎 \(figureCount) figure\(figureCount == 1 ? "" : "s")"
+                figuresBadge.isHidden = false
+            } else {
+                figuresBadge.isHidden = true
+            }
         }
-        
+
+        timeLabel.stringValue = item.formattedTime
         updateBackground()
     }
     
@@ -456,11 +567,11 @@ private class HistoryCardView: NSView {
             timeLabel.textColor = NSColor.white.withAlphaComponent(0.7)
             figuresBadge.textColor = NSColor.white.withAlphaComponent(0.7)
         } else {
-            let bgColor: NSColor = isEvenRow 
-                ? .controlBackgroundColor 
+            let bgColor: NSColor = isEvenRow
+                ? .controlBackgroundColor
                 : .controlBackgroundColor.withAlphaComponent(0.5)
             layer?.backgroundColor = bgColor.cgColor
-            textLabel.textColor = .labelColor
+            textLabel.textColor = isFailedItem ? .systemOrange : .labelColor
             timeLabel.textColor = .tertiaryLabelColor
             figuresBadge.textColor = .secondaryLabelColor
         }


### PR DESCRIPTION
Two related History/recovery improvements, branched from `main`.

## 1. Inline hover-to-copy in History

The old flow was clunky: click a row to *select* it, then move to a bottom **Copy Selected** button. The action was disconnected from the item.

Now each row reveals a **copy icon on hover** — click it to copy that row instantly with a brief "Copied!" title flash. The bottom "Copy Selected" button is gone (Clear All stays; a small "Hover a row to copy" hint sits where it was). Double-click-to-copy still works.

```
┌─────────────────────────────────────────┐
│ Fix the auth bug in login flow      [⧉] │  ← appears on hover
│ Today 9:42 AM                           │
├─────────────────────────────────────────┤
│ Add caller dictation local API      [⧉] │
│ Today 9:18 AM                           │
└─────────────────────────────────────────┘
  [ Clear All ]              Hover a row to copy
```

## 2. Recover failed transcriptions instead of wasting the audio

**The problem:** on a hard transcription failure, `transcribe()` showed "Failed" and then deleted the temp WAV (`removeItem(at: audioURL)`). Audio was only ever preserved on *success in dev mode*. So whatever you said was lost — nothing to re-run.

**Now:**
- **Auto-retry once.** A hard failure retries automatically before giving up (transient model errors are common; empty-output already had its own retry/chunk fallback).
- **Preserve + surface for manual retry.** If it still fails, the recording is saved and a **failed entry** is recorded in History (shown in orange with a **Retry** button). Clicking Retry re-runs the saved audio and replaces the row with the recovered text.

### How it's built
- Extracted the transcription pipeline into `computeTranscript(...)` so the initial attempt, the auto-retry, and manual retry share one path.
- `handleTranscriptionFailure(...)` preserves the audio (no longer dev-mode-only) and records a retryable entry (paste-mode dictation only — not the local API path).
- `TranscriptionItem` gains an optional, backward-compatible `failed` flag plus an identity-preserving init / `updating(text:failed:)`. `HistoryStore` gains `add(..., failed:)` and `update(_:)`.
- `retryFailedTranscription(_:completion:)` transcribes the saved file and updates the entry in place.

### Notes / scope
- Manual retry transcribes the **whole file**; figure (screenshot) positions aren't persisted, so a recovered transcript won't have `[Figure N]` interleaving (the auto-retry, which still has the in-memory figures, does).
- Failed entries are only created for normal dictation, not local-API/caller requests (those return the error to the caller).
- Branched from `main`; independent of the clipboard (#14) and full-screen-screenshot (#15) PRs, though all touch `AppDelegate`, so a small rebase may be needed depending on merge order.

## Testing
- Builds clean (`xcodebuild ... -skipMacroValidation`, and via `./run.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
