### PR TITLE
feat: add model deletion + redesign model cards

### DIFF
--- a/Hearsay/AppDelegate.swift
+++ b/Hearsay/AppDelegate.swift
@@ -1341,6 +1341,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 self.prewarmActiveTranscriber()
             }
         }
+        controller.isTranscriptionInProgress = { [weak self] in
+            self?.isTranscribing ?? false
+        }
         controller.onCleanupSettingsChanged = { [weak self] in
             guard let self = self else { return }
             if CleanupModelDownloader.shared.isEnabled && CleanupModelDownloader.shared.isModelInstalled() {

--- a/Hearsay/Models/ModelDownloader.swift
+++ b/Hearsay/Models/ModelDownloader.swift
@@ -4,6 +4,23 @@ import WhisperKit
 
 private let downloadLogger = Logger(subsystem: "com.swair.hearsay", category: "download")
 
+enum ModelDownloaderError: LocalizedError {
+    case busy
+    case invalidModel
+    case deletionIncomplete
+
+    var errorDescription: String? {
+        switch self {
+        case .busy:
+            return "A download is in progress."
+        case .invalidModel:
+            return "Unsupported model."
+        case .deletionIncomplete:
+            return "Some model files could not be removed."
+        }
+    }
+}
+
 /// Downloads models with progress reporting.
 /// Supports qwen_asr, WhisperKit, and FluidAudio/Parakeet variants.
 final class ModelDownloader: NSObject, ObservableObject, URLSessionDownloadDelegate {
@@ -115,6 +132,29 @@ final class ModelDownloader: NSObject, ObservableObject, URLSessionDownloadDeleg
                 return nil
             }
         }
+
+        /// Legacy cache path components for older WhisperKit folder layouts.
+        var whisperLegacyCachePathComponents: [String]? {
+            switch self {
+            case .whisperTinyEn:
+                return ["openai", "whisper-tiny.en"]
+            case .whisperSmallEn:
+                return ["openai", "whisper-small.en"]
+            case .small, .large, .parakeetEnglishV2, .parakeetMultilingualV3:
+                return nil
+            }
+        }
+
+        /// All on-disk cache directories (current + legacy) where this Whisper model may live.
+        /// Single source of truth for both install detection and deletion.
+        var whisperCacheDirectories: [URL] {
+            let root = Constants.whisperModelsRootDirectory
+            return [whisperCachePathComponents, whisperLegacyCachePathComponents]
+                .compactMap { $0 }
+                .map { components in
+                    components.reduce(root) { $0.appendingPathComponent($1, isDirectory: true) }
+                }
+        }
         
         var files: [String] {
             switch self {
@@ -199,6 +239,11 @@ final class ModelDownloader: NSObject, ObservableObject, URLSessionDownloadDeleg
         }
         UserDefaults.standard.set(model.rawValue, forKey: Self.selectedModelDefaultsKey)
     }
+
+    /// Clear the persisted active-model preference (e.g. after deleting the active model with none left).
+    func clearSelectedModelPreference() {
+        UserDefaults.standard.removeObject(forKey: Self.selectedModelDefaultsKey)
+    }
     
     /// Check if a model is installed
     func isModelInstalled(_ model: Model) -> Bool {
@@ -213,35 +258,10 @@ final class ModelDownloader: NSObject, ObservableObject, URLSessionDownloadDeleg
             }
             return true
         case .whisperKit:
-            // Primary expected cache path for current WhisperKit versions
-            if let cachePathComponents = model.whisperCachePathComponents {
-                let modelPath = cachePathComponents.reduce(Constants.whisperModelsRootDirectory) { partialURL, component in
-                    partialURL.appendingPathComponent(component, isDirectory: true)
-                }
-                if FileManager.default.fileExists(atPath: modelPath.path) {
-                    return true
-                }
+            // Installed if any current/legacy cache directory exists.
+            return model.whisperCacheDirectories.contains { directory in
+                FileManager.default.fileExists(atPath: directory.path)
             }
-
-            // Backward-compatible fallback for older folder layouts
-            let legacyPathComponents: [String]
-            switch model {
-            case .whisperTinyEn:
-                legacyPathComponents = ["openai", "whisper-tiny.en"]
-            case .whisperSmallEn:
-                legacyPathComponents = ["openai", "whisper-small.en"]
-            case .small, .large, .parakeetEnglishV2, .parakeetMultilingualV3:
-                legacyPathComponents = []
-            }
-
-            if !legacyPathComponents.isEmpty {
-                let legacyPath = legacyPathComponents.reduce(Constants.whisperModelsRootDirectory) { partialURL, component in
-                    partialURL.appendingPathComponent(component, isDirectory: true)
-                }
-                return FileManager.default.fileExists(atPath: legacyPath.path)
-            }
-
-            return false
         case .parakeet:
             guard let parakeetModel = model.parakeetModel else {
                 return false
@@ -256,6 +276,58 @@ final class ModelDownloader: NSObject, ObservableObject, URLSessionDownloadDeleg
     /// Get list of installed models
     func installedModels() -> [Model] {
         Model.availableModels.filter { isModelInstalled($0) }
+    }
+
+    /// Delete an installed model's files from disk. Backend-specific.
+    /// Throws if removal fails or the model is still detected as installed afterward.
+    func delete(_ model: Model) async throws {
+        guard !isDownloading else {
+            throw ModelDownloaderError.busy
+        }
+
+        downloadLogger.info("Deleting model \(model.rawValue)")
+
+        do {
+            switch model.backend {
+            case .qwenASR:
+                let modelDir = Constants.modelsDirectory.appendingPathComponent(model.rawValue)
+                if FileManager.default.fileExists(atPath: modelDir.path) {
+                    try FileManager.default.removeItem(at: modelDir)
+                }
+
+            case .whisperKit:
+                for directory in model.whisperCacheDirectories
+                where FileManager.default.fileExists(atPath: directory.path) {
+                    try FileManager.default.removeItem(at: directory)
+                }
+
+            case .parakeet:
+                guard let parakeetModel = model.parakeetModel else {
+                    throw ModelDownloaderError.invalidModel
+                }
+                // Removes all cached dirs and stops the helper if this model is active.
+                try await ParakeetClient.shared.deleteCaches(parakeetModel)
+            }
+
+            // Verify the model is actually gone.
+            if isModelInstalled(model) {
+                throw ModelDownloaderError.deletionIncomplete
+            }
+        } catch {
+            downloadLogger.error("Failed to delete \(model.rawValue): \(error.localizedDescription)")
+            DiagnosticLog.shared.event(
+                "model.delete_failed",
+                level: .error,
+                fields: ["model": model.rawValue, "backend": "\(model.backend)"]
+                    .merging(DiagnosticLog.shared.errorFields(for: error)) { current, _ in current }
+            )
+            throw error
+        }
+
+        DiagnosticLog.shared.event("model.deleted", fields: [
+            "model": model.rawValue,
+            "backend": "\(model.backend)"
+        ])
     }
     
     /// Start downloading a model

--- a/Hearsay/UI/SettingsWindow.swift
+++ b/Hearsay/UI/SettingsWindow.swift
@@ -22,6 +22,8 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
     var onWindowClosed: (() -> Void)?
     var onModelChanged: (() -> Void)?
     var onCleanupSettingsChanged: (() -> Void)?
+    /// Returns true while a transcription is running; used to block model deletion.
+    var isTranscriptionInProgress: (() -> Bool)?
     
     private let tabView = NSTabView()
     private var settingsTab: SettingsTabView!
@@ -85,6 +87,9 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         modelsTab = ModelsTabView(frame: NSRect(x: 0, y: 0, width: 540, height: 400))
         modelsTab.onModelSelected = { [weak self] in
             self?.onModelChanged?()
+        }
+        modelsTab.isTranscriptionInProgress = { [weak self] in
+            self?.isTranscriptionInProgress?() ?? false
         }
         let modelsItem = NSTabViewItem(identifier: "models")
         modelsItem.label = "Models"
@@ -832,6 +837,8 @@ private class AboutInfoRowView: NSView {
 private class ModelsTabView: NSView {
 
     var onModelSelected: (() -> Void)?
+    /// Returns true if a transcription is currently running (delete is blocked while it is).
+    var isTranscriptionInProgress: (() -> Bool)?
 
     private let titleLabel = NSTextField(labelWithString: "Manage Models")
     private let subtitleLabel = NSTextField(labelWithString: "Choose a speech model backend and set it as active.")
@@ -845,6 +852,7 @@ private class ModelsTabView: NSView {
     private let detailLabel = NSTextField(labelWithString: "")
 
     private var selectedModel: ModelDownloader.Model = .small
+    private var isDeleting = false
     private var cancellables = Set<AnyCancellable>()
 
     override init(frame: NSRect) {
@@ -879,6 +887,9 @@ private class ModelsTabView: NSView {
             for model in models[chunkStart..<min(chunkStart + 2, models.count)] {
                 let card = SettingsModelCardView(model: model, isSelected: false) { [weak self] in
                     self?.selectModel(model)
+                }
+                card.onDelete = { [weak self] in
+                    self?.requestDelete(model)
                 }
                 row.addArrangedSubview(card)
                 modelCards[model] = card
@@ -991,19 +1002,24 @@ private class ModelsTabView: NSView {
         let downloader = ModelDownloader.shared
         let active = downloader.selectedModelPreference()
 
+        let controlsDisabled = downloader.isDownloading || isDeleting
         for model in ModelDownloader.Model.availableModels {
             let card = modelCards[model]
             card?.setSelected(model == selectedModel)
             card?.setInstalled(downloader.isModelInstalled(model))
             card?.setActive(active == model)
-            card?.isEnabled = !downloader.isDownloading
+            card?.isEnabled = !controlsDisabled
         }
 
         let selectedInstalled = downloader.isModelInstalled(selectedModel)
+        detailLabel.textColor = .secondaryLabelColor
 
         if downloader.isDownloading {
             actionButton.isHidden = true
             progressContainer.isHidden = false
+        } else if isDeleting {
+            actionButton.isHidden = true
+            progressContainer.isHidden = true
         } else {
             actionButton.isHidden = false
             progressContainer.isHidden = true
@@ -1016,6 +1032,86 @@ private class ModelsTabView: NSView {
                 detailLabel.stringValue = "Installed: \(installedNames). Active: \(active.displayName)."
             } else {
                 detailLabel.stringValue = "Installed: \(installedNames)."
+            }
+        }
+    }
+
+    private func requestDelete(_ model: ModelDownloader.Model) {
+        let downloader = ModelDownloader.shared
+        guard !downloader.isDownloading, !isDeleting else { return }
+        guard downloader.isModelInstalled(model) else { return }
+
+        // Defensive: don't pull files out from under an in-flight transcription.
+        if isTranscriptionInProgress?() == true {
+            let alert = NSAlert()
+            alert.messageText = "Transcription in Progress"
+            alert.informativeText = "Hearsay is currently transcribing. Wait for it to finish, then try deleting the model again."
+            alert.alertStyle = .warning
+            alert.addButton(withTitle: "OK")
+            alert.runModal()
+            return
+        }
+
+        let isActive = downloader.selectedModelPreference() == model
+        let isLastModel = downloader.installedModels().count <= 1
+
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        if isLastModel {
+            // Deleting the last installed model leaves nothing for transcription,
+            // regardless of whether it is the persisted "active" one.
+            alert.messageText = "Delete the only installed model?"
+            alert.informativeText = "“\(model.displayName)” (\(model.estimatedSizeString)) is the only installed model. Deleting it leaves no model available for transcription until you download another. Are you sure?"
+        } else if isActive {
+            alert.messageText = "Delete the active model?"
+            alert.informativeText = "“\(model.displayName)” (\(model.estimatedSizeString)) is currently active. Hearsay will switch to another installed model after deletion."
+        } else {
+            alert.messageText = "Delete this model?"
+            alert.informativeText = "This removes “\(model.displayName)” (\(model.estimatedSizeString)) from disk. You can re-download it anytime."
+        }
+        alert.addButton(withTitle: "Delete")
+        alert.addButton(withTitle: "Cancel")
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        isDeleting = true
+        detailLabel.stringValue = "Deleting \(model.displayName)…"
+        refresh()
+
+        let wasActive = downloader.selectedModelPreference() == model
+
+        Task { [weak self] in
+            // Perform the (potentially large) file removal off the main thread.
+            let deleteError: Error?
+            do {
+                try await downloader.delete(model)
+                deleteError = nil
+            } catch {
+                deleteError = error
+            }
+
+            await MainActor.run {
+                guard let self else { return }
+                self.isDeleting = false
+
+                if let deleteError {
+                    self.refresh()
+                    self.detailLabel.textColor = .systemRed
+                    self.detailLabel.stringValue = "Couldn't delete \(model.displayName): \(deleteError.localizedDescription)"
+                    return
+                }
+
+                if wasActive {
+                    if let next = downloader.installedModels().first {
+                        downloader.setSelectedModelPreference(next)
+                    } else {
+                        downloader.clearSelectedModelPreference()
+                    }
+                    // Active model changed → reconfigure transcriber + status bar.
+                    self.onModelSelected?()
+                }
+
+                self.refresh()
             }
         }
     }
@@ -1060,8 +1156,9 @@ private class ModelsTabView: NSView {
         y -= 34
 
         let rows = Int(ceil(Double(ModelDownloader.Model.availableModels.count) / 2.0))
-        let selectorWidth: CGFloat = min(680, bounds.width - 40)
-        let selectorHeight: CGFloat = CGFloat(rows) * 100 + CGFloat(max(0, rows - 1)) * 12
+        let selectorWidth: CGFloat = min(900, bounds.width - 40)
+        let rowSpacing = modelSelector.spacing
+        let selectorHeight: CGFloat = CGFloat(rows) * SettingsModelCardView.cardHeight + CGFloat(max(0, rows - 1)) * rowSpacing
         modelSelector.frame = NSRect(x: centerX - selectorWidth / 2, y: y - selectorHeight, width: selectorWidth, height: selectorHeight)
         y -= selectorHeight + 24
 
@@ -1082,20 +1179,26 @@ private class SettingsModelCardView: NSView {
     
     private let model: ModelDownloader.Model
     private let onSelect: () -> Void
+    /// Invoked when the user taps the trash button (only present when installed).
+    var onDelete: (() -> Void)?
     private var selected: Bool
     private var installed: Bool = false
     private var active: Bool = false
-    
+
     private let containerBox = NSBox()
     private let nameLabel = NSTextField(labelWithString: "")
     private let sizeLabel = NSTextField(labelWithString: "")
     private let descLabel = NSTextField(labelWithString: "")
-    private let checkmark = NSTextField(labelWithString: "✓")
-    private let downloadedBadge = NSTextField(labelWithString: "✓ Downloaded")
-    private let activeBadge = NSTextField(labelWithString: "Active")
-    
+    /// Single status chip (top-right): "Active" or "Downloaded" — never both. Hidden when not installed.
+    private let statusPill = NSView()
+    private let statusLabel = NSTextField(labelWithString: "")
+    private let deleteButton = NSButton()
+
     var isEnabled: Bool = true {
-        didSet { alphaValue = isEnabled ? 1.0 : 0.5 }
+        didSet {
+            alphaValue = isEnabled ? 1.0 : 0.5
+            deleteButton.isEnabled = isEnabled
+        }
     }
     
     init(model: ModelDownloader.Model, isSelected: Bool, onSelect: @escaping () -> Void) {
@@ -1118,30 +1221,46 @@ private class SettingsModelCardView: NSView {
         
         nameLabel.stringValue = model.displayName
         nameLabel.font = .systemFont(ofSize: 14, weight: .semibold)
+        nameLabel.lineBreakMode = .byTruncatingTail
+        nameLabel.maximumNumberOfLines = 1
         containerBox.addSubview(nameLabel)
-        
+
         sizeLabel.stringValue = model.estimatedSizeString
         sizeLabel.font = .systemFont(ofSize: 11)
         sizeLabel.textColor = .secondaryLabelColor
         containerBox.addSubview(sizeLabel)
-        
+
         descLabel.stringValue = model.description
         descLabel.font = .systemFont(ofSize: 11)
         descLabel.textColor = .tertiaryLabelColor
+        descLabel.lineBreakMode = .byWordWrapping
+        descLabel.maximumNumberOfLines = 2
+        descLabel.cell?.truncatesLastVisibleLine = true
         containerBox.addSubview(descLabel)
-        
-        checkmark.font = .systemFont(ofSize: 16, weight: .bold)
-        checkmark.textColor = .systemBlue
-        containerBox.addSubview(checkmark)
-        
-        downloadedBadge.font = .systemFont(ofSize: 10, weight: .medium)
-        downloadedBadge.textColor = .systemGreen
-        containerBox.addSubview(downloadedBadge)
-        
-        activeBadge.font = .systemFont(ofSize: 10, weight: .medium)
-        activeBadge.textColor = .systemBlue
-        activeBadge.alignment = .right
-        containerBox.addSubview(activeBadge)
+
+        // Status chip (top-right): one rounded tinted pill, set in updateUI().
+        statusPill.wantsLayer = true
+        statusPill.layer?.cornerRadius = 9
+        containerBox.addSubview(statusPill)
+
+        statusLabel.font = .systemFont(ofSize: 10, weight: .semibold)
+        statusLabel.alignment = .center
+        statusPill.addSubview(statusLabel)
+
+        deleteButton.bezelStyle = .inline
+        deleteButton.isBordered = false
+        deleteButton.imagePosition = .imageOnly
+        deleteButton.image = NSImage(systemSymbolName: "trash", accessibilityDescription: "Delete model")
+        deleteButton.contentTintColor = .systemRed
+        deleteButton.toolTip = "Delete this downloaded model"
+        deleteButton.target = self
+        deleteButton.action = #selector(deleteTapped)
+        containerBox.addSubview(deleteButton)
+    }
+
+    @objc private func deleteTapped() {
+        guard isEnabled else { return }
+        onDelete?()
     }
     
     func setSelected(_ selected: Bool) {
@@ -1160,41 +1279,81 @@ private class SettingsModelCardView: NSView {
     }
     
     private func updateUI() {
+        // Selection is shown by the border alone (no separate checkmark).
         containerBox.borderColor = selected ? .systemBlue : .separatorColor
-        checkmark.isHidden = !selected
-        downloadedBadge.isHidden = !installed
-        activeBadge.isHidden = !active
+        containerBox.borderWidth = selected ? 2 : 1
+
+        // One status chip: Active (green) takes precedence over Downloaded (blue); hidden when not installed.
+        if active {
+            statusLabel.stringValue = "Active"
+            statusLabel.textColor = .systemGreen
+            statusPill.layer?.backgroundColor = NSColor.systemGreen.withAlphaComponent(0.16).cgColor
+            statusPill.isHidden = false
+        } else if installed {
+            statusLabel.stringValue = "Downloaded"
+            statusLabel.textColor = .systemBlue
+            statusPill.layer?.backgroundColor = NSColor.systemBlue.withAlphaComponent(0.16).cgColor
+            statusPill.isHidden = false
+        } else {
+            statusPill.isHidden = true
+        }
+
+        deleteButton.isHidden = !installed
+        needsLayout = true
     }
     
     override func layout() {
         super.layout()
-        
+
         containerBox.frame = bounds
-        
-        let padding: CGFloat = 12
-        let contentWidth = bounds.width - padding * 2 - 24
+
+        let padding: CGFloat = 16
+        let contentWidth = bounds.width - padding * 2
         var y = bounds.height - padding - 18
-        
-        nameLabel.frame = NSRect(x: padding, y: y, width: contentWidth, height: 18)
-        checkmark.sizeToFit()
-        checkmark.frame.origin = NSPoint(x: bounds.width - padding - checkmark.frame.width, y: y)
-        
-        y -= 18
+
+        // Status pill: top-right, vertically aligned with the name row.
+        var pillWidth: CGFloat = 0
+        if !statusPill.isHidden {
+            statusLabel.sizeToFit()
+            let pillHeight: CGFloat = 18
+            let hInset: CGFloat = 9
+            pillWidth = ceil(statusLabel.frame.width) + hInset * 2
+            statusPill.frame = NSRect(x: bounds.width - padding - pillWidth, y: y, width: pillWidth, height: pillHeight)
+            statusLabel.frame = NSRect(
+                x: hInset,
+                y: (pillHeight - statusLabel.frame.height) / 2,
+                width: statusPill.bounds.width - hInset * 2,
+                height: statusLabel.frame.height
+            )
+        }
+
+        // Name row: left, ending before the pill so they never collide.
+        let nameRightInset = pillWidth > 0 ? pillWidth + 8 : 0
+        nameLabel.frame = NSRect(x: padding, y: y, width: contentWidth - nameRightInset, height: 18)
+
+        y -= 22
         sizeLabel.frame = NSRect(x: padding, y: y, width: contentWidth, height: 16)
-        
-        y -= 18
-        descLabel.frame = NSRect(x: padding, y: y, width: bounds.width - padding * 2, height: 16)
-        
-        y -= 18
-        downloadedBadge.sizeToFit()
-        downloadedBadge.frame.origin = NSPoint(x: padding, y: y)
-        
-        activeBadge.sizeToFit()
-        activeBadge.frame.origin = NSPoint(x: bounds.width - padding - activeBadge.frame.width, y: y)
+
+        // Description: up to two wrapped lines, in the band between the size row and the trash.
+        let descHeight: CGFloat = 32
+        y -= descHeight + 4
+        descLabel.frame = NSRect(x: padding, y: y, width: contentWidth, height: descHeight)
+
+        // Trash button: alone in the bottom-right (only when installed).
+        let trashSize: CGFloat = 18
+        deleteButton.frame = NSRect(
+            x: bounds.width - padding - trashSize,
+            y: padding,
+            width: trashSize,
+            height: trashSize
+        )
     }
     
+    /// Shared so ModelsTabView's selector height math stays in sync with the card.
+    static let cardHeight: CGFloat = 136
+
     override var intrinsicContentSize: NSSize {
-        NSSize(width: 220, height: 100)
+        NSSize(width: 260, height: Self.cardHeight)
     }
     
     override func mouseDown(with event: NSEvent) {


### PR DESCRIPTION
## Problem

The Models settings tab let users **download** multiple speech models and mark one **active**, but there was **no way to delete** a downloaded model. Disk filled up (Qwen ~1.3–3.4 GB, Whisper/Parakeet hundreds of MB each) with no in-app way to reclaim it — the only delete code (`ModelManager.delete`) was dead/unused and not wired to any UI.

Separately, the model cards carried three overlapping state signals at once (selection checkmark **+** "Downloaded" **+** "Active") plus the new action, and long names/descriptions clipped at the card edge — visually noisy and inconsistent.

## Solution

**Delete capability**
- `ModelDownloader.delete(_:)` removes a model per backend — Qwen (model dir), WhisperKit (current **and** legacy cache dirs), Parakeet (`ParakeetClient.deleteCaches`) — with post-delete verification and diagnostics logging. Added a `whisperCacheDirectories` helper (reused by `isModelInstalled`) and `clearSelectedModelPreference()`.
- Per-card **trash button** with a native confirmation dialog. Confirmation copy is conditional: a strong "no model left for transcription" warning when deleting the **last installed** model, a "will switch to another model" note when deleting the **active** one, and a plain re-download note otherwise.
- **Defensive handling**: blocks deletion while a transcription is in flight (`isTranscriptionInProgress` wired to `AppDelegate`), disables controls during delete/download, surfaces errors inline, and **auto-repoints** the active model (or clears it) when the active one is removed.

**Card redesign**
- Consolidated state into a **single status pill** (green **Active** / blue **Downloaded** — never both, since active implies downloaded); selection shown by border only.
- Trash moved to its own footer slot; descriptions now **wrap to two lines** instead of clipping; larger cards with consistent padding.

macOS-only; Whisper/Parakeet remain arch-gated, so Intel safely sees only Qwen.

## Demo

### Model card re-design

<img width="972" height="900" alt="image" src="https://github.com/user-attachments/assets/ea6c1c5d-175e-41fe-b061-447e8dbbb7fb" />

###  Deleting an inactive model

https://github.com/user-attachments/assets/5d1c7bbd-e584-4f7f-bda6-1914608b4198


### Deleting an active model

https://github.com/user-attachments/assets/bcd8f448-0dd6-4915-a5bf-ab649354b384


## Testing

Verified end-to-end on a running build (Apple Silicon):
- **Delete non-active model** (Whisper small.en): correct dialog → ~466 MB freed on disk, `model.deleted` diagnostic event logged, active model untouched.
- **Delete active model** (with another installed): "switch to another" warning → active badge moves to the other model, status bar updates, dictation still works.
- **Delete last/only model**: strong "no model for transcription" warning → status bar shows no model, no crash, re-download works.
- **Per-backend paths**: confirmed Qwen dir, Whisper current+legacy caches, and Parakeet caches are actually removed (`isModelInstalled` false after).
- **Defensive**: trash hidden on non-downloaded cards; controls disabled during delete; error path surfaces inline without crashing.
- **Card UI**: status pill colors, two-line description wrapping, no name/description clipping, trash placement — all confirmed visually.
- Rebuilt **green after rebasing onto latest main** (1.0.24).